### PR TITLE
Access token and UID hidden from debug log. 

### DIFF
--- a/Editor/DRP_Main.cs
+++ b/Editor/DRP_Main.cs
@@ -111,7 +111,8 @@ namespace Thry
             var applicationManager = discord.GetApplicationManager();
             applicationManager.GetOAuth2Token((Discord.Result result, ref Discord.OAuth2Token oauth2Token) =>
             {
-                Debug.Log("Access Token " + oauth2Token.AccessToken);
+                Debug.Log("Access Token Acquired");
+                //Debug.Log("Access Token " + oauth2Token.AccessToken);
             });
 
             var userManager = discord.GetUserManager();
@@ -120,7 +121,8 @@ namespace Thry
             {
                 Debug.Log("----------------------------Discord Rich Presence---------------------------");
                 var currentUser = userManager.GetCurrentUser();
-                Debug.Log("Username: \"" + currentUser.Username + "\", Id: \"" + currentUser.Id + "\"");
+                Debug.Log("Username: \"" + currentUser.Username + "\"");
+                //Debug.Log("Username: \"" + currentUser.Username + "\", Id: \"" + currentUser.Id + "\"");
                 Debug.Log("-------------------------------------------------------------------------------");
             };
 


### PR DESCRIPTION
Removes these messages from the debug log, this is useful for streaming development and screen sharing, as showing these on screen would be a security risk (mostly tokens).

Ref: #1 